### PR TITLE
Bring up-to-date and get specs passing.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,11 @@
 source "http://rubygems.org"
 
 gem 'resque', "~> 1.10"
-gem "resque-remora", "~> 0.1.0"
+gem "resque-remora", "~> 0.1.0", git: "git@github.com:keylimetoolbox/resque-remora.git", branch: "bring_up_to_date"
 
 group :development do
   gem "rspec", "~> 2.10.0"
-  gem "bundler", "~> 1.1.3"
+  gem "bundler"
   gem "jeweler", "~> 1.6.4"
   gem "simplecov", ">= 0"
   gem "yajl-ruby", "~>0.8.2", :platforms => :mri

--- a/Rakefile
+++ b/Rakefile
@@ -41,7 +41,7 @@ end
 
 task :default => :spec
 
-require 'rake/rdoctask'
+require 'rdoc/task'
 Rake::RDocTask.new do |rdoc|
   version = File.exist?('VERSION') ? File.read('VERSION') : ""
 

--- a/spec/redis-test.conf
+++ b/spec/redis-test.conf
@@ -99,9 +99,9 @@ dbfilename dump.rdb
 #
 # The DB will be written inside this directory, with the filename specified
 # above using the 'dbfilename' configuration directive.
-# 
+#
 # Also the Append Only File will be created inside this directory.
-# 
+#
 # Note that you must specify a directory here, not a file name.
 dir ./spec/
 
@@ -142,7 +142,7 @@ slave-serve-stale-data yes
 #
 # This should stay commented out for backward compatibility and because most
 # people do not need auth (e.g. they run their own servers).
-# 
+#
 # Warning: since Redis is pretty fast an outside user can try up to
 # 150k passwords per second against a good box. This means that you should
 # use a very strong password otherwise it will be very easy to break.
@@ -196,14 +196,14 @@ slave-serve-stale-data yes
 
 # MAXMEMORY POLICY: how Redis will select what to remove when maxmemory
 # is reached? You can select among five behavior:
-# 
+#
 # volatile-lru -> remove the key with an expire set using an LRU algorithm
 # allkeys-lru -> remove any key accordingly to the LRU algorithm
 # volatile-random -> remove a random key with an expire set
 # allkeys->random -> remove a random key, any key
 # volatile-ttl -> remove the key with the nearest expire time (minor TTL)
 # noeviction -> don't expire at all, just return an error on write operations
-# 
+#
 # Note: with all the kind of policies, Redis will return an error on write
 #       operations, when there are not suitable keys for eviction.
 #
@@ -249,7 +249,7 @@ appendonly no
 # appendfilename appendonly.aof
 
 # The fsync() call tells the Operating System to actually write data on disk
-# instead to wait for more data in the output buffer. Some OS will really flush 
+# instead to wait for more data in the output buffer. Some OS will really flush
 # data on disk, some other OS will just try to do it ASAP.
 #
 # Redis supports three different modes:
@@ -287,91 +287,13 @@ appendfsync everysec
 # the same as "appendfsync none", that in pratical terms means that it is
 # possible to lost up to 30 seconds of log in the worst scenario (with the
 # default Linux settings).
-# 
+#
 # If you have latency problems turn this to "yes". Otherwise leave it as
 # "no" that is the safest pick from the point of view of durability.
 no-appendfsync-on-rewrite no
 
-################################ VIRTUAL MEMORY ###############################
-
-# Virtual Memory allows Redis to work with datasets bigger than the actual
-# amount of RAM needed to hold the whole dataset in memory.
-# In order to do so very used keys are taken in memory while the other keys
-# are swapped into a swap file, similarly to what operating systems do
-# with memory pages.
-#
-# To enable VM just set 'vm-enabled' to yes, and set the following three
-# VM parameters accordingly to your needs.
-
-vm-enabled no
-# vm-enabled yes
-
-# This is the path of the Redis swap file. As you can guess, swap files
-# can't be shared by different Redis instances, so make sure to use a swap
-# file for every redis process you are running. Redis will complain if the
-# swap file is already in use.
-#
-# The best kind of storage for the Redis swap file (that's accessed at random) 
-# is a Solid State Disk (SSD).
-#
-# *** WARNING *** if you are using a shared hosting the default of putting
-# the swap file under /tmp is not secure. Create a dir with access granted
-# only to Redis user and configure Redis to create the swap file there.
-vm-swap-file /tmp/redis.swap
-
-# vm-max-memory configures the VM to use at max the specified amount of
-# RAM. Everything that deos not fit will be swapped on disk *if* possible, that
-# is, if there is still enough contiguous space in the swap file.
-#
-# With vm-max-memory 0 the system will swap everything it can. Not a good
-# default, just specify the max amount of RAM you can in bytes, but it's
-# better to leave some margin. For instance specify an amount of RAM
-# that's more or less between 60 and 80% of your free RAM.
-vm-max-memory 0
-
-# Redis swap files is split into pages. An object can be saved using multiple
-# contiguous pages, but pages can't be shared between different objects.
-# So if your page is too big, small objects swapped out on disk will waste
-# a lot of space. If you page is too small, there is less space in the swap
-# file (assuming you configured the same number of total swap file pages).
-#
-# If you use a lot of small objects, use a page size of 64 or 32 bytes.
-# If you use a lot of big objects, use a bigger page size.
-# If unsure, use the default :)
-vm-page-size 32
-
-# Number of total memory pages in the swap file.
-# Given that the page table (a bitmap of free/used pages) is taken in memory,
-# every 8 pages on disk will consume 1 byte of RAM.
-#
-# The total swap size is vm-page-size * vm-pages
-#
-# With the default of 32-bytes memory pages and 134217728 pages Redis will
-# use a 4 GB swap file, that will use 16 MB of RAM for the page table.
-#
-# It's better to use the smallest acceptable value for your application,
-# but the default is large in order to work in most conditions.
-vm-pages 134217728
-
-# Max number of VM I/O threads running at the same time.
-# This threads are used to read/write data from/to swap file, since they
-# also encode and decode objects from disk to memory or the reverse, a bigger
-# number of threads can help with big objects even if they can't help with
-# I/O itself as the physical device may not be able to couple with many
-# reads/writes operations at the same time.
-#
-# The special value of 0 turn off threaded I/O and enables the blocking
-# Virtual Memory implementation.
-vm-max-threads 4
 
 ############################### ADVANCED CONFIG ###############################
-
-# Hashes are encoded in a special way (much more memory efficient) when they
-# have at max a given numer of elements, and the biggest element does not
-# exceed a given threshold. You can configure this limits with the following
-# configuration directives.
-hash-max-zipmap-entries 512
-hash-max-zipmap-value 64
 
 # Similarly to hashes, small lists are also encoded in a special way in order
 # to save a lot of space. The special representation is only used when
@@ -393,7 +315,7 @@ set-max-intset-entries 512
 # that is rhashing, the more rehashing "steps" are performed, so if the
 # server is idle the rehashing is never complete and some more memory is used
 # by the hash table.
-# 
+#
 # The default is to use this millisecond 10 times every second in order to
 # active rehashing the main dictionaries, freeing memory when possible.
 #

--- a/spec/redis-test.conf
+++ b/spec/redis-test.conf
@@ -46,10 +46,10 @@ timeout 300
 # warning (only very important / critical messages are logged)
 loglevel debug
 
-# Specify the log file name. Also 'stdout' can be used to force
+# Specify the log file name. Also the empty string can be used to force
 # Redis to log on the standard output. Note that if you use standard
 # output for logging but daemonize, logs will be sent to /dev/null
-logfile stdout
+logfile ""
 
 # To enable logging to the system logger, just set 'syslog-enabled' to yes,
 # and optionally update the other syslog parameters to suit your needs.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,10 +24,14 @@ dir = File.dirname(__FILE__)
 #
 
 at_exit do
-  pid = `ps -e -o pid,command | grep [r]edis-test`.split(" ")[0]
-  puts "Killing test redis server [#{pid}]..."
   `rm -f #{dir}/dump.rdb`
-  Process.kill("KILL", pid.to_i)
+  pid = `ps -e -o pid,command | grep [r]edis.*9736`.split(" ")[0]
+  if pid.to_i >= 100
+    puts "Killing test redis server [#{pid}]..."
+    Process.kill("KILL", pid.to_i)
+  else
+    puts "Found #{pid} for resque-server that is probably not resque, so not killing it."
+  end
 end
 
 puts "Starting redis for testing at localhost:9736..."
@@ -38,7 +42,7 @@ ENV['VERBOSE'] = 'true'
 RSpec.configure do |config|
   config.before(:each) do
     Resque::Plugins::Director::Config.reset!
-    Resque::Plugins::Director::Scaler.stub!(:system) 
+    Resque::Plugins::Director::Scaler.stub!(:system)
     Process.stub!(:kill)
     Resque.redis.flushall
   end


### PR DESCRIPTION
- remove out-of-date Redis config
- update rdoc/tasks reference for latest rdoc
- do not pin Bundler
- Use patched resque-remora for missing #constantize method

Opening this for review, although once frausto/resque-remora#3 is merged, I'll remove the fork of `resque-remora` from the `Gemfile`.
